### PR TITLE
Add responsive styles for mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,35 @@
     .tile .sub{color:var(--muted)}
 
     .gallery{display:grid; grid-template-columns:repeat(auto-fill, minmax(240px,1fr)); gap:12px}
+    @media (max-width: 1100px){
+      .topbar{flex-wrap:wrap; gap:12px;}
+      .search{width:100%; order:3;}
+      .tools{width:100%; justify-content:flex-start;}
+      .hero-inner{grid-template-columns:1fr;}
+    }
+    @media (max-width: 900px){
+      :root{--content-w: 100%;}
+      .wrap{padding:16px 14px;}
+      .grid{grid-template-columns: minmax(0,1fr);}
+      .sidebar{position:static; order:-1;}
+      .topbar{align-items:flex-start;}
+      nav{width:100%; overflow-x:auto; padding-bottom:6px; flex-wrap:nowrap;}
+      nav a{flex:0 0 auto;}
+      .kpi{grid-template-columns:repeat(2,minmax(0,1fr));}
+    }
+    @media (max-width: 600px){
+      body{font-size:15px;}
+      .topbar{flex-direction:column; align-items:flex-start;}
+      .tools{width:100%;}
+      nav{gap:6px; flex-wrap:wrap;}
+      nav a{font-size:13px; padding:7px 10px;}
+      .hero{padding:16px;}
+      article{padding:16px;}
+      .hero .cta{width:100%;}
+      .hero .cta .btn{flex:1 1 auto; text-align:center;}
+      .kpi{grid-template-columns:minmax(0,1fr);}
+      .gallery{grid-template-columns:repeat(auto-fill, minmax(180px,1fr));}
+    }
     .gallery .ph{aspect-ratio: 16/10; border-radius:14px; border:1px solid rgba(255,255,255,.08); display:grid; place-items:center; color:#a4c8ff; background:repeating-linear-gradient(135deg, rgba(130,200,255,.08) 0 12px, rgba(77,212,172,.08) 12px 24px)}
 
     footer{margin:30px 0 40px; color:var(--muted); text-align:center}


### PR DESCRIPTION
## Summary
- add responsive breakpoints to reorganize the header, hero, and content grids on smaller screens
- ensure navigation and tool controls adapt to narrow viewports with horizontal scrolling or wrapping
- tighten spacing and adjust components like KPIs and galleries for mobile usability

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1ddcc6ad0832098659ba413c741a1